### PR TITLE
Added risk header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ wp.call('/checkout/create',
     
     wp.use_production();
 
+## Risk Headers
+
+  You can supply WePay with risk-related information on every API call by passing the WePay-Risk-Token and Client-IP values to the `call` function:
+
+  ```
+	wp.call('/checkout/create',
+		{
+			'account_id': 1723052,
+			'amount': 50,
+	        'currency': 'USD',
+			'short_description': 'Selling 42 Pens',
+			'type': 'goods'
+		},
+		function(response) {
+			console.log('%s', response);
+		},
+		'123e4567-e89b-12d3-a456-426655440000',
+		'100.166.99.123'
+	);
+  ```
+
+  Detailed information regarding the Risk Headers can be found at the [WePay API Documentation]('https://developer.wepay.com/reference/risk_headers')
+
 ## More Information
 
   * [WePay API](https://www.wepay.com/developer) for documentation

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ wp.call('/checkout/create',
 );
 ```
 
-  Detailed information regarding the Risk Headers can be found at the [WePay API Documentation](https://developer.wepay.com/reference/risk_headers)
+Detailed information regarding the Risk Headers can be found at the [WePay API Documentation](https://developer.wepay.com/reference/risk_headers).
 
 ## More Information
 

--- a/README.md
+++ b/README.md
@@ -65,24 +65,24 @@ wp.call('/checkout/create',
 
   You can supply WePay with risk-related information on every API call by passing the WePay-Risk-Token and Client-IP values to the `call` function:
 
-  ```
-	wp.call('/checkout/create',
-		{
-			'account_id': 1723052,
-			'amount': 50,
-	        'currency': 'USD',
-			'short_description': 'Selling 42 Pens',
-			'type': 'goods'
-		},
-		function(response) {
-			console.log('%s', response);
-		},
-		'123e4567-e89b-12d3-a456-426655440000',
-		'100.166.99.123'
-	);
-  ```
+```
+wp.call('/checkout/create',
+	{
+		'account_id': 1723052,
+		'amount': 50,
+        'currency': 'USD',
+		'short_description': 'Selling 42 Pens',
+		'type': 'goods'
+	},
+	function(response) {
+		console.log('%s', response);
+	},
+	'123e4567-e89b-12d3-a456-426655440000',
+	'100.166.99.123'
+);
+```
 
-  Detailed information regarding the Risk Headers can be found at the [WePay API Documentation]('https://developer.wepay.com/reference/risk_headers')
+  Detailed information regarding the Risk Headers can be found at the [WePay API Documentation](https://developer.wepay.com/reference/risk_headers)
 
 ## More Information
 

--- a/lib/wepay.js
+++ b/lib/wepay.js
@@ -1,6 +1,6 @@
 var http = require('https');
 
-exports.version = '0.0.5';
+exports.version = '0.0.6';
 
 exports.WEPAY = function(settings)
 {

--- a/lib/wepay.js
+++ b/lib/wepay.js
@@ -46,7 +46,7 @@ exports.WEPAY = function(settings)
             return this;
         },
 
-        call: function(url, params, callbackFunction) {
+        call: function(url, params, callbackFunction, riskToken, clientIP) {
             options.path = '/v2' + url;
             var _params = JSON.stringify(params);
 
@@ -56,6 +56,14 @@ exports.WEPAY = function(settings)
             // set API Version
             if (settings.api_version){
                 options.headers['Api-Version'] = settings.api_version;
+            }
+
+            // set risk tokens
+            if (riskToken) {
+                options.headers['WePay-Risk-Token'] = riskToken;
+            }
+            if (clientIP) {
+                options.headers['Client-IP'] = clientIP;
             }
 
             var request = http.request(options, function(response) {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
 	"name": "wepay",
-	"version": "0.0.5"
+	"version": "0.0.6"
 }


### PR DESCRIPTION
WePay-Risk-Token and Client-IP are now available headers on all API calls (see: https://developer.wepay.com/reference/risk_headers). This PR adds support for these optional headers.