### PR TITLE
Add getters/setters for client_id, client_secret

### DIFF
--- a/lib/wepay.js
+++ b/lib/wepay.js
@@ -102,6 +102,16 @@ exports.WEPAY = function(settings)
             return settings.api_version;
         },
 
+        get_client_id: function()
+        {
+            return settings.client_id;
+        },
+
+        get_client_secret: function()
+        {
+            return settings.client_secret;
+        },
+
         set_access_token: function(access_token)
         {
             settings.access_token = access_token;
@@ -110,6 +120,16 @@ exports.WEPAY = function(settings)
         set_api_version: function(api_version)
         {
             settings.api_version = api_version;
+        },
+
+        set_client_id: function(client_id)
+        {
+            settings.client_id = client_id;
+        },
+
+        set_client_secret: function(client_secret)
+        {
+            settings.client_secret = client_secret;
         }
     }
 };


### PR DESCRIPTION
We can now add client_secret, client_id to the body params of requests (ex. user/register [https://developer.wepay.com/api/api-calls/user#register](url)) with get_client_id(), get_client_secret():
```
    wp.call('/user/register',
        {
            'client_id': wp.get_client_id(),
            'client_secret': wp.get_client_secret(),
            ...
        },
        function(response) {
            console.log(response);
        }
    );
```