### PR TITLE
set authorization header in call()

### DIFF
--- a/lib/wepay.js
+++ b/lib/wepay.js
@@ -12,7 +12,6 @@ exports.WEPAY = function(settings)
     var _in_production = false,
         options = {
             headers : {
-                'Authorization': 'Bearer ' + settings.access_token,
                 'Content-Type': 'application/json',
                 'User-Agent': 'WePay NodeJS SDK'
             },
@@ -56,6 +55,10 @@ exports.WEPAY = function(settings)
             // set API Version
             if (settings.api_version){
                 options.headers['Api-Version'] = settings.api_version;
+            }
+
+            if (settings.access_token) {
+                options.headers['Authorization'] = 'Bearer ' + settings.access_token;
             }
 
             // set risk tokens

--- a/lib/wepay.js
+++ b/lib/wepay.js
@@ -1,6 +1,6 @@
 var http = require('https');
 
-exports.version = '0.0.7';
+exports.version = '0.0.8';
 
 exports.WEPAY = function(settings)
 {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
 	"name": "wepay",
-	"version": "0.0.7"
+	"version": "0.0.8"
 }


### PR DESCRIPTION
The current version does not add access_token to request after set_access_token()
```
var wp = new wepay({
      'client_id': 'client_id',
      'client_secret': 'client_secret'
    });

wp.set_access_token('a_valid_access_token');
wp.call('/user', {}, function(response) {
    console.log(response);
    // response is error: "could not parse authorization header, a valid access_token is required" 
});
```

Solved by setting authorization header in call() function. 