### PR TITLE
adding client id and secret to request body

### DIFF
--- a/lib/wepay.js
+++ b/lib/wepay.js
@@ -47,6 +47,17 @@ exports.WEPAY = function(settings)
 
         call: function(url, params, callbackFunction, riskToken, clientIP) {
             options.path = '/v2' + url;
+
+            // set client_id
+            if(settings.client_id){
+                params.client_id = settings.client_id;
+            }
+
+            // set client_secret
+            if(settings.client_secret){
+                params.client_secret = settings.client_secret;
+            }
+
             var _params = JSON.stringify(params);
 
             // adjust the content length


### PR DESCRIPTION
prior to code change the request was returning the following:

{"error":"invalid_request","error_description":"client_id parameter is required","error_code":1004}