### PR TITLE
Remove Content-Length calculation

### DIFF
--- a/lib/wepay.js
+++ b/lib/wepay.js
@@ -1,6 +1,6 @@
 var http = require('https');
 
-exports.version = '0.0.8';
+exports.version = '0.0.9';
 
 exports.WEPAY = function(settings)
 {
@@ -49,9 +49,6 @@ exports.WEPAY = function(settings)
             options.path = '/v2' + url;
             var _params = JSON.stringify(params);
 
-            // adjust the content length
-            options.headers['Content-Length'] = _params.length;
-
             // set API Version
             if (settings.api_version){
                 options.headers['Api-Version'] = settings.api_version;
@@ -68,7 +65,7 @@ exports.WEPAY = function(settings)
             if (clientIP) {
                 options.headers['Client-IP'] = clientIP;
             }
-
+            
             var request = http.request(options, function(response) {
                 // setup a variable to hold all of the response info.
                 // it's possible that the response is too larger for NodeJS to handle in a single request
@@ -85,7 +82,7 @@ exports.WEPAY = function(settings)
                     }
                 });
             });
-
+            
             request.write(_params);
 
             request.on('error', function(e) {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
 	"name": "wepay",
-	"version": "0.0.8"
+	"version": "0.0.9"
 }


### PR DESCRIPTION
Addresses #20.  Let the `https` module determine the content length on its own.  No reason
for us to force it.  The current calculation also doesn't work with
extended character sets.